### PR TITLE
Support ingress path prefixing to consolidate under a single ingress host

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -290,6 +290,8 @@ this Pixel Streaming demo deployment is designed using plain
     UNREAL_IMAGE_VERSION=latest
     # a hostname to use (nip.io ip example)
     INGRESS_HOST=my-pixelstream.<load balancer ip>.nip.io
+    # optionally specify ingress path prefix (ie /game)
+    INGRESS_PATH=
     # specify initial TURN service username
     TURN_USER=userx0000
     # also specify a turn password

--- a/deploy/base/routing/routing-ingress.yaml
+++ b/deploy/base/routing/routing-ingress.yaml
@@ -10,13 +10,14 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/affinity: cookie
     nginx.ingress.kubernetes.io/session-cookie-name: pxstream-ingress
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
     kubernetes.io/ingress.class: nginx
     cert-manager.io/issuer: letsencrypt-prod
 spec:
   rules:
     - http:
         paths:
-          - path: "/"
+          - path: /(.*)
             pathType: Prefix
             backend:
               service:

--- a/deploy/base/streaming/stream-runtime.yaml
+++ b/deploy/base/streaming/stream-runtime.yaml
@@ -126,9 +126,9 @@ spec:
             # NOTE: since GPU affinity is established above, it is not necessary
             # to specify the nvidia.com/gpu resource. Rather a CPU request that
             # corresponds to a portion of a single GPU VM is set - thereby allowing
-            # overcommit on the GPU. This approach is not recommended for best performance.
+            # overcommit on the GPU. This approach may have unpredicatable performance.
             requests:
-              cpu: 2500m
+              cpu: 3750m
             # limits:
             #   nvidia.com/gpu: 1
 

--- a/src/player/web/scripts/app.js
+++ b/src/player/web/scripts/app.js
@@ -385,7 +385,7 @@ function playVideoStream() {
 function showPlayOverlay() {
   let img = document.createElement('img');
   img.id = 'playButton';
-  img.src = '/images/Play.png';
+  img.src = 'images/Play.png';
   img.alt = 'Start Streaming';
 	setOverlay('clickableState', img, hookStartStream);
   shouldShowPlayOverlay = false;


### PR DESCRIPTION
- Adds support for `$INGRESS_PATH` on configuration script, declaring a path prefix under which the ingress rules apply
- minor fix in web player for relative pathing