### PR TITLE
Horizontal Autoscaler updated for k8s 1.24-1.26

### DIFF
--- a/deploy/base/routing/routing-hpa.yaml
+++ b/deploy/base/routing/routing-hpa.yaml
@@ -4,7 +4,7 @@
 # ----------------------------------------------------------------------
 ---
 # for traefik router
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: router-autoscaler
@@ -26,7 +26,7 @@ spec:
           averageUtilization: 50
 ---
 # dynamic proxy layer
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: podproxy-autoscaler

--- a/deploy/base/streaming/stream-hpa.yaml
+++ b/deploy/base/streaming/stream-hpa.yaml
@@ -3,7 +3,7 @@
 # The Universal Permissive License (UPL), Version 1.0
 # ----------------------------------------------------------------------
 
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: stream-autoscaler
@@ -53,4 +53,4 @@ spec:
           name: matchmaker
         target:
           type: Value
-          value: 0.90
+          value: '0.90'


### PR DESCRIPTION
Using autoscaling/v2 to be compatible with Kubernetes 1.26, just added to OKE support